### PR TITLE
Import metadata without calling package __init__

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, unicode_literals
 from setuptools import setup
 from codecs import open
 from os import path
-from apkverify.metadata import __title__, __version__, __description__, __url__, __author__, __author_email__, __license__
+exec(open('apkverify/metadata.py').read())
 
 here = path.abspath(path.dirname(__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,9 @@ from __future__ import absolute_import, unicode_literals
 from setuptools import setup
 from codecs import open
 from os import path
-exec(open('apkverify/metadata.py').read())
 
 here = path.abspath(path.dirname(__file__))
+exec(open(path.join(here, 'apkverify/metadata.py')).read())
 
 
 with open(path.join(here, 'README.md'), 'r', encoding='utf-8') as f:


### PR DESCRIPTION
Solution https://stackoverflow.com/a/16084844/3951400

The previous solution was not enough since the __init__.py file will be called everytime something is imported *normally* from the package.

Another solution to this would be to put the metadata py-file outside of the package folder but this would require messy code for importing the py file from the parent folder.